### PR TITLE
Bytebuffer

### DIFF
--- a/AudioCompression/demo/general/ByteBufferDemo.java
+++ b/AudioCompression/demo/general/ByteBufferDemo.java
@@ -1,0 +1,44 @@
+package general;
+
+import java.nio.ByteBuffer;
+
+
+/**
+ * Simple demo showing how to use a byte buffer
+ * @author Eric Addison, Taylor Autry, Josh Musick
+ *
+ */
+public class ByteBufferDemo {
+
+	public static void main(String[] args){
+		
+		// create an array of random floats
+		int N = 10;
+		float[] floatArray = new float[N];
+		for(int i=0; i<N; i++)
+			floatArray[i] = (float)Math.random();
+		
+		// create a ByteBuffer
+		ByteBuffer buffer = ByteBuffer.allocate(N*Float.SIZE/Byte.SIZE);
+		
+		// load the floats into the buffer
+		for(float f : floatArray)
+			buffer.putFloat(f);
+		
+		// rewind the buffer to play back
+		buffer.rewind();
+		
+		// read all the bytes immediately as an array of bytes
+		byte[] floatBytes = buffer.array();
+		System.out.println("The first byte in the buffer is: " + Integer.toHexString((int)floatBytes[0]));
+		
+		// read the floats back from the byte buffer (need to rewind first)
+		buffer.rewind();
+		float readFloat = buffer.getFloat();
+		System.out.println("The first float in the buffer is: " + readFloat);
+		System.out.println("The first float from the original array is: " + floatArray[0]);
+		System.out.println("The difference is: " + (floatArray[0]-readFloat));
+		
+	}
+	
+}

--- a/AudioCompression/demo/general/ByteBufferDemo.java
+++ b/AudioCompression/demo/general/ByteBufferDemo.java
@@ -2,6 +2,8 @@ package general;
 
 import java.nio.ByteBuffer;
 
+import audioCompression.types.testImpls.AudioByteBufferImpl;
+
 
 /**
  * Simple demo showing how to use a byte buffer
@@ -38,6 +40,14 @@ public class ByteBufferDemo {
 		System.out.println("The first float in the buffer is: " + readFloat);
 		System.out.println("The first float from the original array is: " + floatArray[0]);
 		System.out.println("The difference is: " + (floatArray[0]-readFloat));
+		
+		
+		// demo the AudioByteBufferImpl class
+		int Nbb = 4;
+		AudioByteBufferImpl abb = new AudioByteBufferImpl(Nbb);
+		System.out.print("\nHere are the AudioByteBuffer ints: ");
+		for(int i=0; i<Nbb; i++)
+			System.out.print(abb.getBuffer().getInt() + " ");
 		
 	}
 	

--- a/AudioCompression/src/audioCompression/algorithm/ByteBufferizerStep.java
+++ b/AudioCompression/src/audioCompression/algorithm/ByteBufferizerStep.java
@@ -2,33 +2,37 @@ package audioCompression.algorithm;
 
 import audioCompression.types.AudioByteBuffer;
 import audioCompression.types.AudioCompressionType;
+import audioCompression.types.Lines;
 
-public class HuffmanEncoderStep implements AlgorithmStep<AudioByteBuffer, AudioByteBuffer>  {
+public class ByteBufferizerStep implements AlgorithmStep<Lines, AudioByteBuffer>{
 
 	@Override
-	public AudioByteBuffer forward(AudioByteBuffer input) {
+	public AudioByteBuffer forward(Lines input) {
 		// TODO Auto-generated method stub
 		return null;
 	}
 
 	@Override
-	public AudioByteBuffer reverse(AudioByteBuffer input) {
+	public Lines reverse(AudioByteBuffer input) {
 		// TODO Auto-generated method stub
 		return null;
 	}
 
 	@Override
 	public String getName() {
+		// TODO Auto-generated method stub
 		return null;
 	}
 
 	@Override
 	public Class<? extends AudioCompressionType> getInputClass() {
-		return AudioByteBuffer.class;
+		// TODO Auto-generated method stub
+		return Lines.class;
 	}
 
 	@Override
 	public Class<? extends AudioCompressionType> getOutputClass() {
+		// TODO Auto-generated method stub
 		return AudioByteBuffer.class;
 	}
 

--- a/AudioCompression/src/audioCompression/algorithm/CompressedAudioFileWriter.java
+++ b/AudioCompression/src/audioCompression/algorithm/CompressedAudioFileWriter.java
@@ -1,19 +1,19 @@
 package audioCompression.algorithm;
 
+import audioCompression.types.AudioByteBuffer;
 import audioCompression.types.AudioCompressionType;
-import audioCompression.types.CompressedAudio;
-import audioCompression.types.EncodedLines;
+import audioCompression.types.CompressedAudioFile;
 
-public class BitstreamFormatterStep implements AlgorithmStep<EncodedLines, CompressedAudio> {
+public class CompressedAudioFileWriter implements AlgorithmStep<AudioByteBuffer, CompressedAudioFile> {
 
 	@Override
-	public CompressedAudio forward(EncodedLines input) {
+	public CompressedAudioFile forward(AudioByteBuffer input) {
 		// TODO Auto-generated method stub
 		return null;
 	}
 
 	@Override
-	public EncodedLines reverse(CompressedAudio input) {
+	public AudioByteBuffer reverse(CompressedAudioFile input) {
 		// TODO Auto-generated method stub
 		return null;
 	}
@@ -26,12 +26,12 @@ public class BitstreamFormatterStep implements AlgorithmStep<EncodedLines, Compr
 
 	@Override
 	public Class<? extends AudioCompressionType> getInputClass() {
-		return EncodedLines.class;
+		return AudioByteBuffer.class;
 	}
 
 	@Override
 	public Class<? extends AudioCompressionType> getOutputClass() {
-		return CompressedAudio.class;
+		return CompressedAudioFile.class;
 	}
 
 }

--- a/AudioCompression/src/audioCompression/compressors/AudioCompressor.java
+++ b/AudioCompression/src/audioCompression/compressors/AudioCompressor.java
@@ -1,6 +1,6 @@
 package audioCompression.compressors;
 
-import audioCompression.types.CompressedAudio;
+import audioCompression.types.CompressedAudioFile;
 import audioCompression.types.RawAudio;
 
 
@@ -12,8 +12,8 @@ import audioCompression.types.RawAudio;
  */
 public interface AudioCompressor {
 
-	public CompressedAudio compress(RawAudio rawInput);
+	public CompressedAudioFile compress(RawAudio rawInput);
 	
-	public RawAudio decompress(CompressedAudio compressedInput);
+	public RawAudio decompress(CompressedAudioFile compressedInput);
 	
 }

--- a/AudioCompression/src/audioCompression/compressors/StrippedDownMP3.java
+++ b/AudioCompression/src/audioCompression/compressors/StrippedDownMP3.java
@@ -1,7 +1,7 @@
 package audioCompression.compressors;
 
 import audioCompression.algorithm.*;
-import audioCompression.types.CompressedAudio;
+import audioCompression.types.CompressedAudioFile;
 import audioCompression.types.RawAudio;
 
 /**
@@ -24,17 +24,18 @@ public class StrippedDownMP3 implements AudioCompressor{
 	public StrippedDownMP3() {
 		pipeline.addStep(new FilterBankStep());
 		pipeline.addStep(new MdctStep());
+		pipeline.addStep(new ByteBufferizerStep());
 		pipeline.addStep(new HuffmanEncoderStep());
-		pipeline.addStep(new BitstreamFormatterStep());
+		pipeline.addStep(new CompressedAudioFileWriter());
 	}
 	
 	@Override
-	public CompressedAudio compress(RawAudio rawInput){
-		return (CompressedAudio) pipeline.processForward(rawInput);
+	public CompressedAudioFile compress(RawAudio rawInput){
+		return (CompressedAudioFile) pipeline.processForward(rawInput);
 	}
 	
 	@Override
-	public RawAudio decompress(CompressedAudio compressedInput){
+	public RawAudio decompress(CompressedAudioFile compressedInput){
 		return (RawAudio) pipeline.processReverse(compressedInput);
 	}
 	

--- a/AudioCompression/src/audioCompression/types/AudioByteBuffer.java
+++ b/AudioCompression/src/audioCompression/types/AudioByteBuffer.java
@@ -1,0 +1,17 @@
+package audioCompression.types;
+
+import java.nio.ByteBuffer;
+
+public class AudioByteBuffer implements AudioCompressionType{
+
+	private ByteBuffer buffer;
+	
+	AudioByteBuffer(ByteBuffer buffer) {
+		this.buffer = buffer;
+	}
+	
+	public ByteBuffer getBuffer(){
+		return buffer;
+	}
+
+}

--- a/AudioCompression/src/audioCompression/types/AudioByteBuffer.java
+++ b/AudioCompression/src/audioCompression/types/AudioByteBuffer.java
@@ -6,7 +6,7 @@ public class AudioByteBuffer implements AudioCompressionType{
 
 	private ByteBuffer buffer;
 	
-	AudioByteBuffer(ByteBuffer buffer) {
+	public AudioByteBuffer(ByteBuffer buffer) {
 		this.buffer = buffer;
 	}
 	

--- a/AudioCompression/src/audioCompression/types/CompressedAudio.java
+++ b/AudioCompression/src/audioCompression/types/CompressedAudio.java
@@ -1,5 +1,0 @@
-package audioCompression.types;
-
-public class CompressedAudio implements AudioCompressionType {
-
-}

--- a/AudioCompression/src/audioCompression/types/CompressedAudioFile.java
+++ b/AudioCompression/src/audioCompression/types/CompressedAudioFile.java
@@ -1,0 +1,5 @@
+package audioCompression.types;
+
+public class CompressedAudioFile implements AudioCompressionType {
+
+}

--- a/AudioCompression/src/audioCompression/types/testImpls/AudioByteBufferImpl.java
+++ b/AudioCompression/src/audioCompression/types/testImpls/AudioByteBufferImpl.java
@@ -1,0 +1,18 @@
+package audioCompression.types.testImpls;
+
+import java.nio.ByteBuffer;
+import java.util.Random;
+
+import audioCompression.types.AudioByteBuffer;
+
+public class AudioByteBufferImpl extends AudioByteBuffer{
+
+	public AudioByteBufferImpl(int N) {
+		super(ByteBuffer.allocate(N*(Integer.SIZE/Byte.SIZE)));
+		Random r = new Random(System.currentTimeMillis()); 
+		for(int i=0; i<N; i++)
+			getBuffer().putInt(r.nextInt());
+		getBuffer().rewind();
+	}
+
+}

--- a/AudioCompression/test/audioCompression/compressors/StrippedDownMP3Test.java
+++ b/AudioCompression/test/audioCompression/compressors/StrippedDownMP3Test.java
@@ -7,8 +7,9 @@ import org.junit.Test;
 public class StrippedDownMP3Test {
 
 	@Test
-	public void test() {
-		fail("Not yet implemented");
+	public void instantiate() {
+		StrippedDownMP3 compressor = new StrippedDownMP3();
+		assertNotNull(compressor);
 	}
 
 }


### PR DESCRIPTION
Hey guys,

Here are a few changes to start using a Java `ByteBuffer`, which will allow us to just pass around a collection of bytes after a certain point. The canges include:
- A new `AudioCompressionType` called `AudioByteBuffer`, which just hold a `ByteBuffer` for us to use
- A new `AlgorithmStep` skeleton called `ByteBufferizerStep`, which will convert the MDCT output to bytes
- Update to existing classes to use the new types, including now having the Huffman step input AND output an `AudioByteBuffer`
- A simple demo of how to use the Java `ByteBuffer` class

I think with this change, we will be able to implement the Huffman encoder with absolutely NO assumptions about the incoming data, just that it is a bunch of bytes. You could implement the `HuffmanStep` class to just be a very thin wrapper around the code you have for Huffman, and just send in the `byte[]` array you get from the `ByteBuffer`, or something like that.

There is a test class called `AudioByteBufferImpl` that you can use, Taylor, for testing out your encoder. It just holds a given number of random ints. There is a block of code in the `AudioByteBufferDemo` class that shows how to instantiate and use it.

Let me know if this looks OK and I'll merge it in. Thanks!