### PR TITLE
Feature pipeline events

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -3,6 +3,8 @@ bin
 .classpath
 .project
 .settings
+output_wavs/
+*.jet
 
 # IntelliJ files
 .idea

--- a/AudioCompression/demo/audioCompression/types/FileCompressDemo.java
+++ b/AudioCompression/demo/audioCompression/types/FileCompressDemo.java
@@ -29,10 +29,10 @@ public class FileCompressDemo {
 	
 		long endTime = System.nanoTime();
 		
-		long compressTime = midTime - startTime;
-		long decompressTime = endTime - midTime;
+		double compressTime = (double)(midTime - startTime) / 1000000.0;
+		double decompressTime = (double)(endTime - midTime) / 1000000.0;
 		
-		System.out.println("Compression Time of " + file.getName() + " was " + String.valueOf(compressTime) + " and decompress Time was " + String.valueOf(decompressTime));
+		System.out.println("Compression Time of " + file.getName() + " was " + String.valueOf(compressTime) + " (ms) and decompress Time was " + String.valueOf(decompressTime) + " (ms)");
 		
 	}
 	

--- a/AudioCompression/demo/audioCompression/types/FileCompressDemo.java
+++ b/AudioCompression/demo/audioCompression/types/FileCompressDemo.java
@@ -14,16 +14,18 @@ public class FileCompressDemo {
 	{
 		StrippedDownMP3 pipeline = new StrippedDownMP3();
 		
+		AudioFile aFile = new AudioFile(file.getPath());
+		
 		/// This doesn't appear to work.  The StrippedDownMP3 expects RawAudio not WavAudio
-		WavAudioInput wav = new WavAudioInput(file, 48000/32, 0);
+		//WavAudioInput wav = new WavAudioInput(file, 48000/32, 0);
 		long startTime = System.nanoTime();
-		CompressedAudioFile out = pipeline.compress(wav, "name_compressed.jet");
+		CompressedAudioFile out = pipeline.compress(aFile, "name_compressed.jet");
 		
 		System.out.println("Output string should be [ name_compressed.jet ] and actually was [ " + out.GetCompressedFilename() + " ]");
 		
 		
 		long midTime = System.nanoTime();
-		RawAudio wavOut = pipeline.decompress(out, "name_decompressed.wav");
+		AudioFile wavOut = pipeline.decompress(out, "name_decompressed.wav");
 	
 		long endTime = System.nanoTime();
 		

--- a/AudioCompression/demo/audioCompression/types/FileCompressDemo.java
+++ b/AudioCompression/demo/audioCompression/types/FileCompressDemo.java
@@ -4,11 +4,11 @@ import java.io.File;
 
 import libs.wavParser.WavFile;
 import audioCompression.compressors.StrippedDownMP3;
+import audioCompression.compressors.FullAudioCompressor;
 
 public class FileCompressDemo {
-
-//	private StrippedDownMP3 pipeline;
 	
+	protected FullAudioCompressor fComp = new FullAudioCompressor();
 	
 	public static void RunTest(File file)
 	{

--- a/AudioCompression/demo/general/FullCompressionDemo.java
+++ b/AudioCompression/demo/general/FullCompressionDemo.java
@@ -11,6 +11,33 @@ public class FullCompressionDemo {
 
 	protected FullAudioCompressor compressor = new FullAudioCompressor();
 	
+	public void RunCompressDecompress(File file, StringBuilder sb)
+	{
+		String name = file.getName();
+		long startTime = System.nanoTime();	
+		AudioFile aFile = new AudioFile(file.getPath());
+		String sName = name.substring(0, name.length() - 4);
+		
+		sb.append(name + "," + sName + ".jet,");
+		CompressedAudioFile cfile = compressor.compress(aFile, "../data/" + sName + ".jet");
+		long midTime = System.nanoTime();
+		compressor.decompress(cfile, "../output_wavs/" + sName +".wav");
+		long endTime = System.nanoTime();
+		
+		double compressTime = (double)(midTime - startTime) / 1000000.0;
+		double decompressTime = (double)(endTime - midTime) / 1000000.0;
+		
+		
+		compressor.AddMetrics(sb);
+		sb.append(String.valueOf(compressTime));
+		sb.append(",");
+		sb.append(String.valueOf(decompressTime));
+		sb.append(",");
+		
+		sb.append('\n');
+		
+	}
+	
 	public void RunTest1(File[] files) 
 	{
 		try 
@@ -19,39 +46,25 @@ public class FullCompressionDemo {
 			PrintWriter pw = new PrintWriter(new File("../data/test1_data.csv"));
 	        StringBuilder sb = new StringBuilder();
 	        
-	        sb.append("original filename,compressed name,compression time (ms),decompression time (ms),");
+	        sb.append("original filename,compressed name,");
 	        compressor.AddMetricTitles(sb);
+	        sb.append("Total Compression time (ms), Total Decompression time (ms),");
 	        sb.append('\n');
 						
 			for (File file: files) {
 				String name = file.getName();
 				if (name.matches("^(.*wav)")) {
-					System.out.println("\nLoading wav file: " + name);
-					
+					System.out.println("Loading wav file: " + name + "\n");
+									
 					/// do loops in here, to modify the settings on the compressor
 					
-					
-					long startTime = System.nanoTime();	
-					AudioFile aFile = new AudioFile(file.getPath());
-					String sName = name.substring(0, name.length() - 4);
-					
-					sb.append(name + "," + sName + ".jet,");
-					CompressedAudioFile cfile = compressor.compress(aFile, "../data/" + sName + ".jet");
-					long midTime = System.nanoTime();
-					compressor.decompress(cfile, "../output_wavs/" + sName +".wav");
-					long endTime = System.nanoTime();
-					
-					double compressTime = (double)(midTime - startTime) / 1000000.0;
-					double decompressTime = (double)(endTime - midTime) / 1000000.0;
-					
-					sb.append(String.valueOf(compressTime));
-					sb.append(",");
-					sb.append(String.valueOf(decompressTime));
-					sb.append(",");
-					
-					compressor.AddMetrics(sb);
-					
-					sb.append('\n');
+					int windowLen = 256;
+					for (int i = 0; i < 5; ++i) {
+						System.out.println("Running test with Window size of " + String.valueOf(windowLen) + "\n");
+						compressor.SetSignalWindowSize(windowLen);
+						RunCompressDecompress(file, sb);				
+						windowLen *= 2;
+					}
 				}
 			}
 			

--- a/AudioCompression/demo/general/FullCompressionDemo.java
+++ b/AudioCompression/demo/general/FullCompressionDemo.java
@@ -73,6 +73,7 @@ public class FullCompressionDemo {
 		
 		demo.RunTest1(files);		
 		
+		System.out.println("----------------------\n-- Test 1 complete --\n----------------------");
 	}
 
 	

--- a/AudioCompression/demo/general/FullCompressionDemo.java
+++ b/AudioCompression/demo/general/FullCompressionDemo.java
@@ -1,0 +1,81 @@
+package general;
+
+import java.io.File;
+import java.io.PrintWriter;
+
+import audioCompression.compressors.FullAudioCompressor;
+import audioCompression.types.AudioFile;
+import audioCompression.types.CompressedAudioFile;
+
+public class FullCompressionDemo {
+
+	protected FullAudioCompressor compressor = new FullAudioCompressor();
+	
+	public void RunTest1(File[] files) 
+	{
+		try 
+		{
+			// Create a csv file for logging the metric data
+			PrintWriter pw = new PrintWriter(new File("../data/test1_data.csv"));
+	        StringBuilder sb = new StringBuilder();
+	        
+	        sb.append("original filename,compressed name,compression time (ms),decompression time (ms),");
+	        compressor.AddMetricTitles(sb);
+	        sb.append('\n');
+						
+			for (File file: files) {
+				String name = file.getName();
+				if (name.matches("^(.*wav)")) {
+					System.out.println("\nLoading wav file: " + name);
+					
+					/// do loops in here, to modify the settings on the compressor
+					
+					
+					long startTime = System.nanoTime();	
+					AudioFile aFile = new AudioFile(file.getPath());
+					String sName = name.substring(0, name.length() - 4);
+					
+					sb.append(name + "," + sName + ".jet,");
+					CompressedAudioFile cfile = compressor.compress(aFile, "../data/" + sName + ".jet");
+					long midTime = System.nanoTime();
+					compressor.decompress(cfile, "../output_wavs/" + sName +".wav");
+					long endTime = System.nanoTime();
+					
+					double compressTime = (double)(midTime - startTime) / 1000000.0;
+					double decompressTime = (double)(endTime - midTime) / 1000000.0;
+					
+					sb.append(String.valueOf(compressTime));
+					sb.append(",");
+					sb.append(String.valueOf(decompressTime));
+					sb.append(",");
+					
+					compressor.AddMetrics(sb);
+					
+					sb.append('\n');
+				}
+			}
+			
+			pw.write(sb.toString());
+			pw.close();			
+			
+		}
+		catch (Exception e)
+		{
+			System.err.println(e);
+		}
+	}	
+	
+	public static void main(String[] args) {
+
+		FullCompressionDemo demo = new FullCompressionDemo();
+		
+		File[] files = new File("../src_wavs").listFiles();
+		
+		demo.RunTest1(files);		
+		
+	}
+
+	
+	
+}
+

--- a/AudioCompression/src/audioCompression/algorithm/CompressionPipeline.java
+++ b/AudioCompression/src/audioCompression/algorithm/CompressionPipeline.java
@@ -68,7 +68,19 @@ public class CompressionPipeline {
 		STAGE_REVERSE_END
 	};
 	
-	private void OnPipelineEvent(PipelineStage stage, String prevStage, String nextStage) {}
+	private void OnPipelineEvent(PipelineStage stage, String prevStage, String nextStage)
+	{
+		String msg = "- Pipeline Event ";
+		if (stage == PipelineStage.STAGE_FORWARD_BEGIN) {
+			msg += "Begin - ";
+		} else if (stage == PipelineStage.STAGE_FORWARD_INTERMEDIATE) {
+			msg += "Between " + prevStage + " and " + nextStage + " -"; 
+		} else if (stage == PipelineStage.STAGE_FORWARD_END) {
+			msg += "Ending -"; 
+		}
+		msg += "\n";
+		System.out.printf(msg);
+	}
 	
 	
 	/**
@@ -85,14 +97,25 @@ public class CompressionPipeline {
 					+ "expected " + pipeline.getFirst().getInputClass() 
 					+ ", got " + input.getClass());
 		
-		OnPipelineEvent(STAGE_FORWARD_BEGIN, "", pipeline.getFirst().getName());
+		OnPipelineEvent(PipelineStage.STAGE_FORWARD_BEGIN, "--", pipeline.getFirst().getName());
 		
 		Iterator<AlgorithmStep> iter = pipeline.iterator();
 		AudioCompressionType workingData = input;
+		AlgorithmStep prevStep = null;
+		boolean first = false;
 		while(iter.hasNext()){
-			AlgorithmStep nextStep = iter.next(); 
+			AlgorithmStep nextStep = iter.next();
+			if (first) {
+				OnPipelineEvent(PipelineStage.STAGE_FORWARD_INTERMEDIATE, 
+						prevStep.getName(), nextStep.getName());
+			}
 			workingData = nextStep.forward(workingData, name);
+			prevStep = nextStep;
+			first = true;
 		}
+		
+		OnPipelineEvent(PipelineStage.STAGE_FORWARD_END, pipeline.getLast().getName(), "--");
+		
 		return workingData;
 	}
 	

--- a/AudioCompression/src/audioCompression/algorithm/CompressionPipeline.java
+++ b/AudioCompression/src/audioCompression/algorithm/CompressionPipeline.java
@@ -78,7 +78,7 @@ public class CompressionPipeline {
 		} else if (stage == PipelineStage.STAGE_FORWARD_END) {
 			msg += "Forward Ending -"; 
 		} else if (stage == PipelineStage.STAGE_REVERSE_BEGIN) {
-			msg += "Reverse Begin - ";
+			msg += "Reverse Begin with " + nextStage + " - ";
 		} else if (stage == PipelineStage.STAGE_REVERSE_INTERMEDIATE) {
 			msg += "Reverse Between " + prevStage + " and " + nextStage + " -"; 
 		} else if (stage == PipelineStage.STAGE_REVERSE_END) {

--- a/AudioCompression/src/audioCompression/algorithm/CompressionPipeline.java
+++ b/AudioCompression/src/audioCompression/algorithm/CompressionPipeline.java
@@ -58,6 +58,18 @@ public class CompressionPipeline {
 	
 	}
 	
+	// These enums describe the pipeline stage for triggering the pipeline callback
+	enum PipelineStage {
+		STAGE_FORWARD_BEGIN,
+		STAGE_FORWARD_INTERMEDIATE,
+		STAGE_FORWARD_END,
+		STAGE_REVERSE_BEGIN,
+		STAGE_REVERSE_INTERMEDIATE,
+		STAGE_REVERSE_END
+	};
+	
+	private void OnPipelineEvent(PipelineStage stage, String prevStage, String nextStage) {}
+	
 	
 	/**
 	 * Process an input dataset through the pipeline in the 
@@ -72,6 +84,8 @@ public class CompressionPipeline {
 					+ "input type to processForward() -- "
 					+ "expected " + pipeline.getFirst().getInputClass() 
 					+ ", got " + input.getClass());
+		
+		OnPipelineEvent(STAGE_FORWARD_BEGIN, "", pipeline.getFirst().getName());
 		
 		Iterator<AlgorithmStep> iter = pipeline.iterator();
 		AudioCompressionType workingData = input;

--- a/AudioCompression/src/audioCompression/algorithm/InputOutputStep.java
+++ b/AudioCompression/src/audioCompression/algorithm/InputOutputStep.java
@@ -14,6 +14,12 @@ public class InputOutputStep implements AlgorithmStep<AudioFile, RawAudio>{
 	private RawAudio inputAudio;
 	private RawAudio outputWav;
 	private float rmsError;
+	private long inputSize;
+	
+	// retrieve the input file size in bytes?
+	public long getInputSize() {
+		return inputSize;
+	}
 	
 	public int getWindowLength() {
 		return windowLength;
@@ -45,7 +51,9 @@ public class InputOutputStep implements AlgorithmStep<AudioFile, RawAudio>{
 
 	@Override
 	public RawAudio forward(AudioFile input, String name) {
-		inputAudio = new WavAudioInput(new File(input.getFilename()), windowLength, windowOverlap);
+		WavAudioInput wav = new WavAudioInput(new File(input.getFilename()), windowLength, windowOverlap); 
+		inputAudio = wav;
+		inputSize = wav.getInputSize();
 		return inputAudio;
 	}
 

--- a/AudioCompression/src/audioCompression/algorithm/SerializationStep.java
+++ b/AudioCompression/src/audioCompression/algorithm/SerializationStep.java
@@ -27,6 +27,7 @@ import audioCompression.types.CompressedAudioFile;
 public class SerializationStep implements AlgorithmStep<AudioByteBuffer, CompressedAudioFile> {
 
 	private static final String NAME = "Serializer";
+	private int compressFileSize = 0;
 	
 	@Override
 	public CompressedAudioFile forward(AudioByteBuffer input, String name) {
@@ -39,6 +40,8 @@ public class SerializationStep implements AlgorithmStep<AudioByteBuffer, Compres
 			FileOutputStream strm = new FileOutputStream(file, false); 
 			FileChannel channel = strm.getChannel();
 			fileSize = input.getBuffer().remaining();
+			
+			compressFileSize = fileSize;
 			
 			// Writes a sequence of bytes to this channel from the given buffer.
 			channel.write(input.getBuffer());
@@ -85,6 +88,10 @@ public class SerializationStep implements AlgorithmStep<AudioByteBuffer, Compres
 		}
 		return null;
 	}
+	
+	public int getCompressFileSize() {
+		return compressFileSize;
+	}
 
 	@Override
 	public String getName() {
@@ -100,5 +107,7 @@ public class SerializationStep implements AlgorithmStep<AudioByteBuffer, Compres
 	public Class<? extends AudioCompressionType> getOutputClass() {
 		return CompressedAudioFile.class;
 	}
+	
+	
 
 }

--- a/AudioCompression/src/audioCompression/algorithm/TimedCompressionPipeline.java
+++ b/AudioCompression/src/audioCompression/algorithm/TimedCompressionPipeline.java
@@ -1,0 +1,67 @@
+package audioCompression.algorithm;
+
+import audioCompression.algorithm.CompressionPipeline;
+
+public class TimedCompressionPipeline extends CompressionPipeline {
+
+	/**
+	 * This function handles the intermediate steps of the compress and decompress pipeline,
+	 * this provides a handle to capture step specific metrics, ie time etc.
+	 * @param stage		Enum of which part of the cycle is happening, start, middle, end
+	 * @param nextIndex	Index of the next step that will be ran, invalid for end stage type (there is no next step)
+	 * @param prevStage	Name of previous stage performed
+	 * @param nextStage	Name of next stage to be performed
+	 */
+	@Override
+	protected void OnPipelineEvent(PipelineStage stage, int nextIndex, String prevStage, String nextStage)
+	{
+		long curTime = System.nanoTime();
+		String msg = "- Pipeline Event ";
+		if (stage == PipelineStage.STAGE_FORWARD_BEGIN) {
+			compressStartTime = curTime;
+			compressionIntervalTimes = new long[pipeline.size()];
+			msg += "Forward Begin with " + nextStage + " - ";
+		} else if (stage == PipelineStage.STAGE_FORWARD_INTERMEDIATE) {
+			compressionIntervalTimes[nextIndex] = curTime;
+			msg += "Forward Between " + prevStage + " and " + nextStage + " -"; 
+		} else if (stage == PipelineStage.STAGE_FORWARD_END) {
+			compressionIntervalTimes[decompressIntervalTimes.length - 1] = curTime;
+			msg += "Forward Ending -";
+		} else if (stage == PipelineStage.STAGE_REVERSE_BEGIN) {
+			decompressStartTime = curTime;
+			decompressIntervalTimes = new long[pipeline.size()];
+			msg += "Reverse Begin with " + nextStage + " - ";
+		} else if (stage == PipelineStage.STAGE_REVERSE_INTERMEDIATE) {
+			decompressIntervalTimes[nextIndex] = curTime;
+			msg += "Reverse Between " + prevStage + " and " + nextStage + " -"; 
+		} else if (stage == PipelineStage.STAGE_REVERSE_END) {
+			decompressIntervalTimes[decompressIntervalTimes.length - 1] = curTime;
+			msg += "Reverse Ending -";
+		}
+		if (bEnableDebugging) {
+			msg += "\n";
+			System.out.printf(msg);	
+		}		
+	}
+	
+	// these are the persistent compression time values from the pipeline
+	protected long compressStartTime;
+	protected long[] compressionIntervalTimes;
+	protected long decompressStartTime;
+	protected long[] decompressIntervalTimes;
+	
+	protected boolean bEnableDebugging = false;
+	
+	/// Access method to enable verbose printing of pipeline step progress
+	public void SetDebuggingEnable(boolean enable) {
+		bEnableDebugging = enable;
+	}
+	
+	public void GetMetricTitles(StringBuilder sb, boolean mdctEnabled) {
+		
+	}
+	
+	public void GetMetricss(StringBuilder sb, boolean mdctEnabled) {
+		
+	}
+}

--- a/AudioCompression/src/audioCompression/algorithm/TimedCompressionPipeline.java
+++ b/AudioCompression/src/audioCompression/algorithm/TimedCompressionPipeline.java
@@ -62,7 +62,7 @@ public class TimedCompressionPipeline extends CompressionPipeline {
 		bEnableDebugging = enable;
 	}
 	
-	public void GetMetricTitles(StringBuilder sb, boolean mdctEnabled) {
+	public void GetMetricTitles(StringBuilder sb) {
 		sb.append("Comp IO Time (ms),");
 		sb.append("Decomp IO Time (ms),");
 		sb.append("Comp Filter Bank Time (ms),");
@@ -77,7 +77,7 @@ public class TimedCompressionPipeline extends CompressionPipeline {
 		sb.append("Decomp Serialize Time (ms),");
 	}
 	
-	public void GetMetricss(StringBuilder sb) {
+	public void GetMetrics(StringBuilder sb) {
 		double oneMill = 1000000.0;
 		double compT = (double)(compressionIntervalTimes[0] - compressStartTime) / oneMill;
 		double decompT = (double)(decompressIntervalTimes[0] - decompressStartTime) / oneMill;
@@ -92,7 +92,7 @@ public class TimedCompressionPipeline extends CompressionPipeline {
 		for (int i = 1; i < num; ++i) {
 						
 			compT = (double)(compressionIntervalTimes[i] - compressionIntervalTimes[i - 1]) / oneMill;
-			decompT = (double)(decompressIntervalTimes[i] - decompressIntervalTimes[i - 1]) / oneMill;
+			decompT = (double)(decompressIntervalTimes[i - 1] - decompressIntervalTimes[i]) / oneMill;
 			
 			int index = i;
 			if (!m_mdctEnabled && i > 1) {

--- a/AudioCompression/src/audioCompression/compressors/AudioCompressor.java
+++ b/AudioCompression/src/audioCompression/compressors/AudioCompressor.java
@@ -2,7 +2,8 @@ package audioCompression.compressors;
 
 import audioCompression.types.CompressedAudioFile;
 import audioCompression.types.RawAudio;
-
+import audioCompression.types.AudioCompressionType;
+import audioCompression.types.AudioFile;
 
 /**
  * Interface to define operation of our AudioCompressors.
@@ -12,8 +13,8 @@ import audioCompression.types.RawAudio;
  */
 public interface AudioCompressor {
 
-	public CompressedAudioFile compress(RawAudio rawInput, String compressedName);
+	public CompressedAudioFile compress(AudioCompressionType input, String compressedName);
 	
-	public RawAudio decompress(CompressedAudioFile compressedInput, String decompressName);
+	public AudioFile decompress(CompressedAudioFile compressedInput, String decompressName);
 	
 }

--- a/AudioCompression/src/audioCompression/compressors/AudioCompressor.java
+++ b/AudioCompression/src/audioCompression/compressors/AudioCompressor.java
@@ -1,7 +1,6 @@
 package audioCompression.compressors;
 
 import audioCompression.types.CompressedAudioFile;
-import audioCompression.types.RawAudio;
 import audioCompression.types.AudioCompressionType;
 import audioCompression.types.AudioFile;
 

--- a/AudioCompression/src/audioCompression/compressors/FullAudioCompressor.java
+++ b/AudioCompression/src/audioCompression/compressors/FullAudioCompressor.java
@@ -22,7 +22,7 @@ import audioCompression.types.*;
 public class FullAudioCompressor implements AudioCompressor {
 
 	// Pipeline which will hold the various steps
-	private CompressionPipeline pipeline = new CompressionPipeline();
+	private TimedCompressionPipeline pipeline = new TimedCompressionPipeline();
 	
 	// Internal flag for knowing if the MDCT step is currently active
 	private boolean m_bMDCTEnabled;
@@ -137,6 +137,8 @@ public class FullAudioCompressor implements AudioCompressor {
 		sb.append("NumSubBands_FilterBank,");
 		sb.append("FilterBankLength,");
 		sb.append("Adaptive Byte Buff,");
+		
+		pipeline.GetMetricTitles(sb);
 	}
 	
 	public void AddMetrics(StringBuilder sb)
@@ -149,6 +151,8 @@ public class FullAudioCompressor implements AudioCompressor {
 		sb.append(",");
 		sb.append(String.valueOf(m_bAdaptiveByteBuffEnabled));
 		sb.append(",");
+		
+		pipeline.GetMetrics(sb);
 	}
 	
 }

--- a/AudioCompression/src/audioCompression/compressors/FullAudioCompressor.java
+++ b/AudioCompression/src/audioCompression/compressors/FullAudioCompressor.java
@@ -43,6 +43,9 @@ public class FullAudioCompressor implements AudioCompressor {
 	/// Create the huffman encoder
 	private HuffmanEncoderStep huffman = new HuffmanEncoderStep();
 	
+	// Create the serialization step
+	private SerializationStep serialStep = new SerializationStep();
+	
 	public FullAudioCompressor()
 	{
 		m_bMDCTEnabled = false;
@@ -52,7 +55,7 @@ public class FullAudioCompressor implements AudioCompressor {
 		pipeline.addStep(fBankStep);
 		pipeline.addStep(subBand_BB);
 		pipeline.addStep(huffman);
-		pipeline.addStep(new SerializationStep());		
+		pipeline.addStep(serialStep);		
 		
 	}
 	
@@ -133,18 +136,37 @@ public class FullAudioCompressor implements AudioCompressor {
 	
 	public void AddMetricTitles(StringBuilder sb)
 	{
-		sb.append("WindowLength,");
-		sb.append("NumSubBands_FilterBank,");
-		sb.append("FilterBankLength,");
-		sb.append("Adaptive Byte Buff,");
+		sb.append("Window Length,");
+		sb.append("Window Overlap,");
+		sb.append("RMS Error,");
+		sb.append("Input Size (kB),");
+		sb.append("Compress File Size,");
 		
-		pipeline.GetMetricTitles(sb);
+		sb.append("FilterBank Num SubBands ,");
+		sb.append("FilterBank Length,");
+		sb.append("Adaptive Byte Buff,");
+	
+		
+		// add other metric "titles" here (always trail with a comma)
+		
+		/// This will add the timer titles from the pipeline
+		pipeline.GetMetricTitles(sb);		
+		
 	}
 	
 	public void AddMetrics(StringBuilder sb)
 	{
 		sb.append(String.valueOf(io.getWindowLength()));
 		sb.append(",");
+		sb.append(String.valueOf(io.getWindowOverlap()));
+		sb.append(",");
+		sb.append(String.valueOf(io.getRmsError()));
+		sb.append(",");
+		sb.append(String.valueOf(io.getInputSize() / 1024));
+		sb.append(",");
+		sb.append(String.valueOf(serialStep.getCompressFileSize()));
+		sb.append(",");
+		
 		sb.append(String.valueOf(fBankStep.getnBands()));
 		sb.append(",");
 		sb.append(String.valueOf(fBankStep.getFilterWindowLength()));
@@ -152,7 +174,15 @@ public class FullAudioCompressor implements AudioCompressor {
 		sb.append(String.valueOf(m_bAdaptiveByteBuffEnabled));
 		sb.append(",");
 		
+		
+		// add other metric values here (always trail with a comma)
+		
+		/// This will add the timers from the pipeline
 		pipeline.GetMetrics(sb);
+		
+		
+		
+		
 	}
 	
 }

--- a/AudioCompression/src/audioCompression/compressors/FullAudioCompressor.java
+++ b/AudioCompression/src/audioCompression/compressors/FullAudioCompressor.java
@@ -130,5 +130,25 @@ public class FullAudioCompressor implements AudioCompressor {
 	{
 		io.setWindowLength(winSize);
 	}
-		
+	
+	public void AddMetricTitles(StringBuilder sb)
+	{
+		sb.append("WindowLength,");
+		sb.append("NumSubBands_FilterBank,");
+		sb.append("FilterBankLength,");
+		sb.append("Adaptive Byte Buff,");
+	}
+	
+	public void AddMetrics(StringBuilder sb)
+	{
+		sb.append(String.valueOf(io.getWindowLength()));
+		sb.append(",");
+		sb.append(String.valueOf(fBankStep.getnBands()));
+		sb.append(",");
+		sb.append(String.valueOf(fBankStep.getFilterWindowLength()));
+		sb.append(",");
+		sb.append(String.valueOf(m_bAdaptiveByteBuffEnabled));
+		sb.append(",");
+	}
+	
 }

--- a/AudioCompression/src/audioCompression/compressors/FullAudioCompressor.java
+++ b/AudioCompression/src/audioCompression/compressors/FullAudioCompressor.java
@@ -57,13 +57,13 @@ public class FullAudioCompressor implements AudioCompressor {
 	}
 	
 	@Override // compress the given input file
-	public CompressedAudioFile compress(RawAudio rawInput, String compressedName) {
-		return (CompressedAudioFile) pipeline.processForward(rawInput, compressedName);
+	public CompressedAudioFile compress(AudioCompressionType input, String compressedName) {
+		return (CompressedAudioFile) pipeline.processForward(input, compressedName);
 	}
 
 	@Override // decompress the given input file
-	public RawAudio decompress(CompressedAudioFile compressedInput, String decompressName) {
-		return (RawAudio) pipeline.processReverse(compressedInput, decompressName);
+	public AudioFile decompress(CompressedAudioFile compressedInput, String decompressName) {
+		return (AudioFile) pipeline.processReverse(compressedInput, decompressName);
 	}
 
 	// Method for toggling the adaptive encoding of the Huffman Step

--- a/AudioCompression/src/audioCompression/compressors/StrippedDownMP3.java
+++ b/AudioCompression/src/audioCompression/compressors/StrippedDownMP3.java
@@ -3,6 +3,8 @@ package audioCompression.compressors;
 import audioCompression.algorithm.*;
 import audioCompression.types.CompressedAudioFile;
 import audioCompression.types.RawAudio;
+import audioCompression.types.AudioCompressionType;
+import audioCompression.types.AudioFile;
 
 /**
  * Our implementation of a stripped down version of MP3 compression.
@@ -25,20 +27,21 @@ public class StrippedDownMP3 implements AudioCompressor{
 	public StrippedDownMP3() {
 		pipeline.addStep(new InputOutputStep());
 		pipeline.addStep(new FilterBankStep());
-		pipeline.addStep(new MdctStep());
-		pipeline.addStep(new LinesByteBufferizerStep());
+	//	pipeline.addStep(new MdctStep());
+		pipeline.addStep(new SubbandsByteBufferizerStep());
+	//	pipeline.addStep(new LinesByteBufferizerStep());
 		pipeline.addStep(new HuffmanEncoderStep());
 		pipeline.addStep(new SerializationStep());
 	}
 	
 	@Override
-	public CompressedAudioFile compress(RawAudio rawInput, String compressedName){
+	public CompressedAudioFile compress(AudioCompressionType rawInput, String compressedName){
 		return (CompressedAudioFile) pipeline.processForward(rawInput, compressedName);
 	}
 	
 	@Override
-	public RawAudio decompress(CompressedAudioFile compressedInput, String decompressName){
-		return (RawAudio) pipeline.processReverse(compressedInput, decompressName);
+	public AudioFile decompress(CompressedAudioFile compressedInput, String decompressName){
+		return (AudioFile) pipeline.processReverse(compressedInput, decompressName);
 	}
 	
 }

--- a/AudioCompression/src/audioCompression/compressors/StrippedDownMP3.java
+++ b/AudioCompression/src/audioCompression/compressors/StrippedDownMP3.java
@@ -2,7 +2,6 @@ package audioCompression.compressors;
 
 import audioCompression.algorithm.*;
 import audioCompression.types.CompressedAudioFile;
-import audioCompression.types.RawAudio;
 import audioCompression.types.AudioCompressionType;
 import audioCompression.types.AudioFile;
 

--- a/AudioCompression/src/audioCompression/types/WavAudioInput.java
+++ b/AudioCompression/src/audioCompression/types/WavAudioInput.java
@@ -24,7 +24,7 @@ public class WavAudioInput implements RawAudio{
 			this.wavFile = WavFile.openWavFile(inputFile);
 			nSamples = wavFile.getNumFrames();
 			this.byteDepth = (wavFile.getValidBits()+7)/8;
-			
+				
 			this.samplesPerWindow = samplesPerWindow;
 			
 			this.windowOverlap = windowOverlap;
@@ -47,6 +47,15 @@ public class WavAudioInput implements RawAudio{
 	public void writeFile(String filename) {
 		// todo - write out the wav file, this will probably not be used much in this class
 		//  but is here for completeness of the interface.
+	}
+	
+	public long getInputSize() {
+		return getByteDepth() * getNChannels() * getNSamples();
+	}
+	
+	@Override
+	public int getByteDepth() {
+		return byteDepth;
 	}
 	
 	@Override
@@ -165,11 +174,6 @@ public class WavAudioInput implements RawAudio{
 					windowBuffer[i][j] = windowBuffer[i][(j+windowIncrement)];
 		}
 		
-	}
-
-	@Override
-	public int getByteDepth() {
-		return byteDepth;
 	}
 
 }

--- a/AudioCompression/src/libs/wavParser/WavReaderTest.java
+++ b/AudioCompression/src/libs/wavParser/WavReaderTest.java
@@ -9,7 +9,7 @@ public class WavReaderTest {
 		try
 		{
 			// Open the wav file specified as the first argument
-			WavFile wavFile = WavFile.openWavFile(new File("../src_wavs/ocean_waves.wav"));
+			WavFile wavFile = WavFile.openWavFile(new File("../src_wavs/ocean_waves_L.wav"));
 
 			// Display information about the wav file
 			wavFile.display();


### PR DESCRIPTION
This pull will include extensive metric logging and timing capability in the FullCompressionDemo.  Adding new metric fields for logging to a csv is simple.  It is currently varying the window size from 256 to 4096 for each input file, and is outputting the relevant data to a single csv for review / analysis. 

This branch also includes an update to the pipeline process forward and reverse.  It adds a callback for doing metric capture / output to he window.  I added a TimedCompressionPipeline, extending the base pipeline to add timers and the logging capability.  This seems to be working well.